### PR TITLE
implement bit shift node

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -7,6 +7,7 @@ import * as transform from './transform';
 export { code, node, transform, Property, PropertyType, Span };
 export { Edge } from './edge';
 export { LoopChecker } from './loop-checker';
+export { ShiftChecker } from './shift-checker';
 export { ISpanAllocatorResult, SpanAllocator } from './span-allocator';
 export { Reachability } from './reachability';
 
@@ -110,6 +111,34 @@ export class Builder {
    */
   public pause(errorCode: number, reason: string): node.Pause {
     return new node.Pause(errorCode, reason);
+  }
+
+  // Shift
+
+  /**
+   * Create a node that packs bits into a field in 
+   * little endian format. 
+   * 
+   *   state[field] <<= value;
+   *
+   * This node does not provide otherwise as this node must
+   * consume bytes upon execution.
+   */
+  public lshift(field: string, bits: number): node.Shift {
+    return new node.Shift(field, bits, true);
+  }
+
+  /**
+   * Create a node that packs bits into a field in 
+   * big endian format. 
+   * 
+   *   state[field] >>= value;
+   *
+   * This node does not provide otherwise as this node must
+   * consume bytes upon execution.
+   */
+  public rshift(field: string, bits: number): node.Shift {
+    return new node.Shift(field, bits, false);
   }
 
   // Span

--- a/src/node/shift.ts
+++ b/src/node/shift.ts
@@ -1,0 +1,29 @@
+import { Node } from './base';
+
+/**
+ * This node consumes and stores an integer into a specified
+ * `field` from the input before forwarding execution.
+ */
+export class Shift extends Node { 
+  /**
+     * @param field State's property name
+     * @param bits number of bits to shift it can be between 1 and 8
+     * @param lshift if true, bits are shifted to the left. 
+     * otherwise, it goes in the opposite direction.
+     */
+  constructor (public readonly field: string, public readonly bits:number, public readonly lshift: boolean){
+    const name = (lshift) ? "lshift" : "rshift";
+    const operation = (bits > 1) ? `_${bits * 8}`: "";
+    super(`${name}_${field}${operation}`);
+    if (/^_/.test(field)) {
+      throw new Error(`Can't use internal field in \`.${name}()\`: "${field}"`);
+    }
+    if (bits < 1 || bits > 8){
+      throw new Error(`bits must be a number between 1 to 8`);
+    }
+  }
+  /** `.otherwise()` is not supported on this type of node as it consumes a bit.
+     * enabling this defeats the purpose.
+     */
+  public otherwise(): this { throw new Error('Not supported'); }
+}

--- a/src/shift-checker.ts
+++ b/src/shift-checker.ts
@@ -1,0 +1,77 @@
+import { debuglog } from 'node:util';
+
+import { Property } from './property';
+import { Node, Shift } from './node';
+import { Reachability } from './reachability';
+
+
+const debug = debuglog('llparse-builder:shift-checker');
+
+/**
+ * Validates shift nodes to find invalid or missing properties or bit sizes
+ */
+export class ShiftChecker {
+  public readonly property_table = new Map<string, Property>();
+  constructor (properties: readonly Property[]){
+    properties.forEach((prop) => {this.property_table.set(prop.name, prop)});
+  }
+
+  /**
+     * validates a single shift node to see if a property exists
+     * to be fed bits to. It also has the ability of checking if numbers
+     * may overflow.
+     * 
+     * @param shift the shift node to check.
+     */
+  private validate_shift(shift: Shift): void{
+    const property = this.property_table.get(shift.field);
+    if (!property){
+      throw new Error(`"${shift.field}" has not been defined for ${shift.name}`);
+    }
+    let size;
+    switch (property.ty){
+      case 'ptr':
+        throw new Error(
+          `${shift.field} cannot be provided to "${shift.name}" because field was defined as a "ptr"`
+        );
+      case 'i8':
+        size = 1;
+        break;
+      case 'i16':
+        size = 2;
+        break;
+      case 'i32':
+        size = 4;
+        break;
+      case 'i64':
+        size = 8;
+        break;
+      default:
+        /* TODO (Vizonex): ensure this is unreachable. */
+        /* UNREACHABLE */
+        size = 0;
+    }
+    // Ensure bits can't overflow...
+    if (shift.bits > size){
+      throw new Error(`${shift.bits} > ${size} and will cause node "${shift.field}" to overflow.`)
+    }
+  }
+
+  /** 
+     * Run shift checker pass on a graph starting from `root`. 
+     * 
+     * @param root Graph root node
+     */
+  public check(root: Node): void {
+    const r = new Reachability();
+    const nodes = r.build(root);
+        
+    for (const node of nodes){
+      if (node instanceof Shift){
+        debug('checking %j', node.name);
+        this.validate_shift(node);
+      }
+    }
+  }
+}
+

--- a/test/shift-checker.test.ts
+++ b/test/shift-checker.test.ts
@@ -64,9 +64,9 @@ describe ('LLParse/ShiftChecker', () => {
         
     /* hypothetically let's say we have an uint32_t in C but we only 
         need to pack a i16 bit integer, this is valid use-case because we can safely
-        back it even if the property is bigger than itself. */
+        pack it even if the property is bigger than itself. */
     b.property('i32', "defined");
-        
+
     start
       .otherwise(rshift);
     rshift.skipTo(start);

--- a/test/shift-checker.test.ts
+++ b/test/shift-checker.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, it, TestContext } from 'node:test';
+import { Builder, ShiftChecker } from '../src/builder';
+
+describe ('LLParse/ShiftChecker', () => {
+  let b: Builder;
+  let sc: ShiftChecker;
+
+  beforeEach(() => {
+    b = new Builder();
+  });
+
+  it('should prohibit undefined properties', (t: TestContext) => {
+    const lshift = b.lshift("undefined", 1);
+    const start = b.node('start');
+        
+    start
+      .otherwise(lshift);
+    lshift.skipTo(start);
+    sc = new ShiftChecker(b.properties);
+
+    t.assert.throws(() => {   
+      sc.check(start);
+    }, /has not been defined for.*undefined/)
+  });
+
+  it('should detect overflowing bits', (t: TestContext) => {
+    const rshift = b.rshift("defined", 8);
+    const start = b.node('start');
+        
+    b.property('i8', "defined");
+        
+    start
+      .otherwise(rshift);
+    rshift.skipTo(start);
+
+
+    sc = new ShiftChecker(b.properties);
+    t.assert.throws(() => {   
+      sc.check(start);
+    }, /and will cause node .* to overflow./);
+
+  });
+
+  it('should detect inapproperate types', (t: TestContext) => {
+    const rshift = b.rshift("defined", 8);
+    const start = b.node('start');
+        
+    b.property('ptr', "defined");
+        
+    start
+      .otherwise(rshift);
+    rshift.skipTo(start);
+
+
+    sc = new ShiftChecker(b.properties);
+    t.assert.throws(() => {   
+      sc.check(start);
+    }, /defined cannot be provided to ".*" because field was defined as a "ptr"/);
+  });
+
+  it('should allow types that are smaller than itself', (t: TestContext) => {
+    const rshift = b.rshift("defined", 2);
+    const start = b.node('start');
+        
+    /* hypothetically let's say we have an uint32_t in C but we only 
+        need to pack a i16 bit integer, this is valid use-case because we can safely
+        back it even if the property is bigger than itself. */
+    b.property('i32', "defined");
+        
+    start
+      .otherwise(rshift);
+    rshift.skipTo(start);
+
+
+    sc = new ShiftChecker(b.properties);
+    t.assert.doesNotThrow(() => sc.check(start));
+  });
+
+
+
+})


### PR DESCRIPTION
I read the old pull request from 6 years ago that attempted to implement integer packing and with my desire to write a new socks5 parser soon that parses negotiation packets on both the client and server's end as part of RFC1928 I knew that doing so would not be an easy task. Currently It requires some functionality that llparse currently doesn't implement. My goal here is to change that entirely as I understand llparse's code architecture pretty well as making a python parody of this library already. My goal however is to use typescript mainly so that others can help me better maintain this future project.

## Goals with this Pull Request

- __To revive the llparse typescript library as a whole__ as well as add a few new features to it so that __llparse__ can continue receiving maintenance.

- Provide a new node that is small and be easy to maintain

- Have actual tests provided to increase the likelihood of these features being added in. 

- A tool which I named `ShiftChecker` named after the `LoopChecker` is also provided to 
    - validate `Shift` nodes for missing fields
    - check for integer sizes that could overflow the parser state's fields
    - check for inappropriate fields that can't be shifted into such as the `ptr` type.

This solution provides the ability to pack bytes and it simplifies @arthurschreiber's original work and makes the implementation smaller.

The reason I would like for a __llsocks5__ library to use typescript however is because more people know how to use llparse in the typescript language which means I could be possibly given outside help as well as better feedback which is why I am doing this all to begin with. I might also look into making an smtp parser even though my understanding of the smtp protocol isn't as good as my understanding with the socks5 protocol is which is why I am working on a new socks5 parser first.

closes #1